### PR TITLE
Fix color5 in OneDark theme

### DIFF
--- a/themes/OneDark.conf
+++ b/themes/OneDark.conf
@@ -10,7 +10,7 @@ color1 #e06c75
 color2 #98c379
 color3 #e5c07b
 color4 #61afef
-color5 #be5046
+color5 #c678dd
 color6 #56b6c2
 color7 #979eab
 color8 #393e48
@@ -18,7 +18,7 @@ color9 #d19a66
 color10 #56b6c2
 color11 #e5c07b
 color12 #61afef
-color13 #be5046
+color13 #c678dd
 color14 #56b6c2
 color15 #abb2bf
 selection_foreground #282c34


### PR DESCRIPTION
`color5` did not match the color specification in [here](https://github.com/joshdick/onedark.vim#color-reference).

---
name: theme-request
about: Use the following template if you want a new theme to be included in the collection.
title: Add <theme> to the collection.
labels: theme request
assignees: dexpota

---
Please, include **theme** in the collection.
